### PR TITLE
[feat] 내식물등록페이지 기능 구현

### DIFF
--- a/lib/screens/plants/my_plant_collection_screen.dart
+++ b/lib/screens/plants/my_plant_collection_screen.dart
@@ -88,6 +88,8 @@ class _MyPlantCollectionScreenState extends State<MyPlantCollectionScreen> {
                     imageUrl: imageUrl, // 이미지 URL
                     dDayWater: dDayWater, // 물 주는 D-Day
                     dDayFertilizer: dDayTogether, // 함께한 D-Day
+                    plantId: plant.id, // Firestore 식물 고유 id
+                    waterCycle: plant['waterCycle'], // 물 주기
                   ),
                   const SizedBox(height: 16),
                 ],

--- a/lib/screens/plants/my_plant_collection_screen.dart
+++ b/lib/screens/plants/my_plant_collection_screen.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 import '../../widgets/components/bottom_navigation_bar.dart';
 import '../../widgets/components/plant_list_item.dart';
 
@@ -20,28 +22,79 @@ class _MyPlantCollectionScreenState extends State<MyPlantCollectionScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final user = FirebaseAuth.instance.currentUser; // 현재 로그인된 사용자
+
     return Scaffold(
       backgroundColor: Colors.white,
       appBar: _buildAppBar(),
-      body: ListView(
-        padding: const EdgeInsets.all(16),
-        children: const[
-          PlantListItem(
-            //context,
-            plantName: '팥이',
-            imageUrl: 'assets/images/sample_plant.png',
-            dDayWater: 1,
-            dDayFertilizer: 220,
-          ),
-          SizedBox(height: 16),
-          PlantListItem(
-            //context,
-            plantName: '콩콩이',
-            imageUrl: 'assets/images/sample_plant.png',
-            dDayWater: 3,
-            dDayFertilizer: 34,
-          ),
-        ],
+      body: StreamBuilder<QuerySnapshot>(
+        // Firestore에서 식물 데이터 가져오기
+        stream: FirebaseFirestore.instance
+            .collection('users')
+            .doc(user!.uid) // 현재 로그인된 사용자
+            .collection('plants')
+            .snapshots(),
+        builder: (context, snapshot) {
+          // 로딩 스피너
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          // 식물이 없는 경우 안내 메시지
+          if (!snapshot.hasData || snapshot.data!.docs.isEmpty) {
+            return const Center(
+              child: Text(
+                "식물을 등록해 보세요!",
+                style: TextStyle(
+                  color: Color(0xFFB3B3B3),
+                  fontSize: 18,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            );
+          }
+
+          // Firestore에서 가져온 데이터
+          final plants = snapshot.data!.docs;
+
+          return ListView.builder(
+            padding: const EdgeInsets.all(16),
+            itemCount: plants.length,
+            itemBuilder: (context, index) {
+              final plant = plants[index]; // 개별 식물 데이터
+              final plantName = plant['plantname'] ?? '식물 이름 없음'; // 식물 이름
+              final imageUrl = plant['imageUrl'] ?? ''; // 이미지 URL
+              final meetingDate = DateTime.parse(plant['meetingDate']); // 처음 만난 날
+              final waterDate = DateTime.parse(plant['waterDate']); // 마지막 물 준 날
+              final waterCycle = (plant['waterCycle'] ?? 0).toInt(); // 물 주기
+
+              // 함께한 D-Day 계산
+              final dDayTogether =
+                  DateTime.now().difference(meetingDate).inDays + 1;
+
+              // 물 주는 D-Day 계산
+              final nextWaterDate = DateTime(
+                waterDate.year,
+                waterDate.month,
+                waterDate.day,
+              ).add(Duration(days: waterCycle));
+              final dDayWater = nextWaterDate.difference(DateTime(DateTime.now().year, DateTime.now().month, DateTime.now().day)).inDays;
+
+              // PlantListItem 위젯 생성
+              return Column(
+                children: [
+                  PlantListItem(
+                    plantName: plantName, // 식물 이름
+                    imageUrl: imageUrl, // 이미지 URL
+                    dDayWater: dDayWater, // 물 주는 D-Day
+                    dDayFertilizer: dDayTogether, // 함께한 D-Day
+                  ),
+                  const SizedBox(height: 16),
+                ],
+              );
+            },
+          );
+        },
       ),
       bottomNavigationBar: MyBottomNavigationBar(
         selectedIndex: _selectedIndex,

--- a/lib/screens/plants/my_plant_register_screen.dart
+++ b/lib/screens/plants/my_plant_register_screen.dart
@@ -67,9 +67,9 @@ class _MyPlantRegisterScreenState extends State<MyPlantRegisterScreen> {
           .add({
         'plantname': _plantNameController.text.trim(),
         'species': _plantSpeciesController.text.trim(),
-        'waterCycle': waterCycle,
-        'fertilizerCycle': fertilizerCycle,
-        'repottingCycle': repottingCycle,
+        'waterCycle': waterCycle.toInt(),
+        'fertilizerCycle': fertilizerCycle.toInt(),
+        'repottingCycle': repottingCycle.toInt(),
         'sunlightLevel': sunlightLevel,
         'waterLevel': waterLevel,
         'temperature': temperature,

--- a/lib/screens/plants/my_plant_register_screen.dart
+++ b/lib/screens/plants/my_plant_register_screen.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:fluttertoast/fluttertoast.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:image_picker/image_picker.dart';
 import 'dart:io';
 import '../modals/cycle_setting_modal.dart';
@@ -38,15 +41,6 @@ class _MyPlantRegisterScreenState extends State<MyPlantRegisterScreen> {
     super.dispose();
   }
 
- /* void _submitForm() {
-    setState(() {
-      isError = !_formKey.currentState!.validate();
-    });
-    if (!isError) {
-      // 완료 처리
-    }
-  }
-*/
   // 사진 선택 함수
   void _pickImage() async {
     final XFile? image = await _picker.pickImage(source: ImageSource.gallery);
@@ -54,6 +48,57 @@ class _MyPlantRegisterScreenState extends State<MyPlantRegisterScreen> {
       setState(() {
         _image = image;
       });
+    }
+  }
+
+  // Firestore에 데이터 저장
+  Future<void> _submitPlantData() async {
+    try {
+      final user = FirebaseAuth.instance.currentUser;
+      if (user == null) {
+        throw Exception("로그인된 사용자가 없습니다.");
+      }
+
+      // Firestore에 저장
+      await FirebaseFirestore.instance
+          .collection('users')
+          .doc(user.uid)
+          .collection('plants')
+          .add({
+        'plantname': _plantNameController.text.trim(),
+        'species': _plantSpeciesController.text.trim(),
+        'waterCycle': waterCycle,
+        'fertilizerCycle': fertilizerCycle,
+        'repottingCycle': repottingCycle,
+        'sunlightLevel': sunlightLevel,
+        'waterLevel': waterLevel,
+        'temperature': temperature,
+        'meetingDate': meetingDate.toIso8601String(),
+        'waterDate': waterDate.toIso8601String(),
+        'imageUrl': _image != null ? _image!.path : null,
+        'createdAt': FieldValue.serverTimestamp(),
+      });
+
+      Fluttertoast.showToast(
+        msg: "식물 등록 성공!",
+        toastLength: Toast.LENGTH_SHORT,
+        gravity: ToastGravity.CENTER,
+        backgroundColor: Color(0xFFECF7F2),
+        textColor: Colors.black,
+        fontSize: 13.0,
+      );
+
+      if (!mounted) return;
+      context.pop(); // 내식물모음페이지로 이동
+
+    } catch (e) {
+      Fluttertoast.showToast(
+        msg: "등록 실패..",
+        toastLength: Toast.LENGTH_SHORT,
+        gravity: ToastGravity.BOTTOM,
+        backgroundColor: Color(0xFFE81010),
+        textColor: Colors.white,
+      );
     }
   }
 
@@ -584,7 +629,7 @@ class _MyPlantRegisterScreenState extends State<MyPlantRegisterScreen> {
           Expanded( // 완료 버튼
             flex: 7,
             child: ElevatedButton(
-              onPressed: () { context.pop(); }, // 데이터 전달 필요
+              onPressed: () { _submitPlantData(); }, // 데이터 저장
               style: ElevatedButton.styleFrom(
                 backgroundColor: Color(0xFF4B7E5B),
                 foregroundColor: Colors.white,

--- a/lib/widgets/components/plant_list_item.dart
+++ b/lib/widgets/components/plant_list_item.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:fluttertoast/fluttertoast.dart';
+import 'dart:io';
 
 // 내 식물 하나
 class PlantListItem extends StatelessWidget {
@@ -36,9 +37,15 @@ class PlantListItem extends StatelessWidget {
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               crossAxisAlignment: CrossAxisAlignment.center,
               children: [
-                _plantName(), // 식물 이름
+                Expanded(
+                  child: _plantName(), // 식물 이름
+                ),
+                const SizedBox(width: 8), // 이름과 이미지 사이 간격
                 _plantImage(context), // 식물 이미지
-                _dDay(), // D-Day
+                const SizedBox(width: 8), // 이미지와 D-Day 사이 간격
+                Expanded(
+                  child: _dDay(), // D-Day
+                ),
               ],
             ),
           ),
@@ -54,8 +61,7 @@ class PlantListItem extends StatelessWidget {
       child: Text(
         plantName,
         style: const TextStyle(
-          fontSize: 16,
-          fontWeight: FontWeight.bold,
+          fontSize: 18,
         ),
         textAlign: TextAlign.center,
         softWrap: true, // 개행 허용
@@ -65,45 +71,52 @@ class PlantListItem extends StatelessWidget {
 
   // 식물 이미지, 물주기 버튼 (중앙)
   Widget _plantImage(BuildContext context) {
-    return Stack(
-      alignment: Alignment.center, // 기본 정렬: 중앙
-      children: [
-        // 중앙: 식물 이미지
-        CircleAvatar(
-          radius: 55,
-          backgroundImage: AssetImage(imageUrl),
-        ),
-        Positioned( // 물주기 버튼
-          bottom: 5,
-          right: 5,
-          child: Container(
-            width: 30, // 버튼 크기
-            height: 30,
-            decoration: BoxDecoration(
-              color: Color(0xFFFFFFFF), // 배경색
-              shape: BoxShape.circle,
-              boxShadow: [
-                BoxShadow(
-                  color: Colors.grey.withOpacity(0.5),
-                  blurRadius: 4,
-                  offset: const Offset(0, 2),
-                ),
-              ],
-            ),
-            child: IconButton(
-              icon: Icon(
-                Icons.water_drop,
-                color: Color(0xFF8FD7FF),
-                size: 20,
+    final file = File(imageUrl);
+
+    return Container(
+      alignment: Alignment.center, // 이미지 항상 가운데
+      child: Stack(
+        alignment: Alignment.center, // 기본 정렬: 중앙
+        children: [
+          // 중앙: 식물 이미지
+          CircleAvatar(
+            radius: 55,
+            backgroundImage: imageUrl.isNotEmpty && File(imageUrl).existsSync()
+                ? FileImage(File(imageUrl)) // 로컬 파일 이미지
+                : AssetImage('assets/images/default_post.png') as ImageProvider, // 기본 이미지
+          ),
+          Positioned(
+            bottom: 5,
+            right: 5,
+            child: Container(
+              width: 30, // 버튼 크기
+              height: 30,
+              decoration: BoxDecoration(
+                color: Color(0xFFFFFFFF), // 배경색
+                shape: BoxShape.circle,
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.grey.withOpacity(0.5),
+                    blurRadius: 4,
+                    offset: const Offset(0, 2),
+                  ),
+                ],
               ),
-              padding: EdgeInsets.zero,
-              onPressed: () {
-                _showWateringDialog(context); // 팝업창
-              },
+              child: IconButton(
+                icon: Icon(
+                  Icons.water_drop,
+                  color: Color(0xFF8FD7FF),
+                  size: 20,
+                ),
+                padding: EdgeInsets.zero,
+                onPressed: () {
+                  _showWateringDialog(context); // 팝업창
+                },
+              ),
             ),
           ),
-        ),
-      ],
+        ],
+      ),
     );
   }
 

--- a/lib/widgets/components/plant_list_item.dart
+++ b/lib/widgets/components/plant_list_item.dart
@@ -1,14 +1,18 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 import 'dart:io';
 
 // 내 식물 하나
-class PlantListItem extends StatelessWidget {
+class PlantListItem extends StatefulWidget  {
   final String plantName;
   final String imageUrl;
   final int dDayWater;
   final int dDayFertilizer;
+  final String plantId; // Firestore의 식물 고유 id
+  final int waterCycle; // 물 주기
 
   const PlantListItem({
     super.key,
@@ -16,7 +20,22 @@ class PlantListItem extends StatelessWidget {
     required this.imageUrl,
     required this.dDayWater,
     required this.dDayFertilizer,
+    required this.plantId,
+    required this.waterCycle,
   });
+
+  @override
+  State<PlantListItem> createState() => _PlantListItemState();
+}
+
+class _PlantListItemState extends State<PlantListItem> {
+  late int dDayWater; // 물주기 버튼을 누르면 바뀜
+
+  @override
+  void initState() {
+    super.initState();
+    dDayWater = widget.dDayWater; // 초기값 설정
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -59,7 +78,7 @@ class PlantListItem extends StatelessWidget {
     return Container(
       alignment: Alignment.center,
       child: Text(
-        plantName,
+        widget.plantName,
         style: const TextStyle(
           fontSize: 18,
         ),
@@ -71,7 +90,7 @@ class PlantListItem extends StatelessWidget {
 
   // 식물 이미지, 물주기 버튼 (중앙)
   Widget _plantImage(BuildContext context) {
-    final file = File(imageUrl);
+    final file = File(widget.imageUrl);
 
     return Container(
       alignment: Alignment.center, // 이미지 항상 가운데
@@ -81,8 +100,8 @@ class PlantListItem extends StatelessWidget {
           // 중앙: 식물 이미지
           CircleAvatar(
             radius: 55,
-            backgroundImage: imageUrl.isNotEmpty && File(imageUrl).existsSync()
-                ? FileImage(File(imageUrl)) // 로컬 파일 이미지
+            backgroundImage: widget.imageUrl.isNotEmpty && file.existsSync()
+                ? FileImage(file) // 로컬 파일 이미지
                 : AssetImage('assets/images/default_post.png') as ImageProvider, // 기본 이미지
           ),
           Positioned(
@@ -129,7 +148,7 @@ class PlantListItem extends StatelessWidget {
           shape: RoundedRectangleBorder(
               borderRadius: BorderRadius.circular(12)),
           title: Text("물 주기"),
-          content: Text("$plantName에게 물을 주시겠습니까?"),
+          content: Text("${widget.plantName}에게 물을 주시겠습니까?"),
           actions: [
             // 아니오 버튼
             TextButton(
@@ -138,10 +157,14 @@ class PlantListItem extends StatelessWidget {
             ),
             // 예 버튼
             TextButton(
-              onPressed: () {
+              onPressed: () async {
                 context.pop(); // 팝업 닫기
-                // 물주기 로직 추가
-                _showToast("$plantName에게 물을 주었습니다!");
+                try {
+                  await _updateWaterDate(); // 물 주기 로직
+                  _showToast("${widget.plantName}에게 물을 주었습니다!");
+                } catch (e) {
+                  _showToast("물 주기 실패..");
+                }
               },
               child: const Text("예"),
             ),
@@ -150,6 +173,34 @@ class PlantListItem extends StatelessWidget {
       },
     );
   }
+
+  Future<void> _updateWaterDate() async {
+    final user = FirebaseAuth.instance.currentUser;
+
+    if (user == null) {
+      throw Exception("로그인된 사용자가 없습니다.");
+    }
+
+    try {
+      // Firestore에서 마지막 물 준 날짜를 오늘로 업데이트
+      await FirebaseFirestore.instance
+          .collection('users')
+          .doc(user.uid)
+          .collection('plants')
+          .doc(widget.plantId) // Firestore 문서 ID
+          .update({
+        'waterDate': DateTime.now().toIso8601String(), // 오늘 날짜로 업데이트
+      });
+
+      // dDayWater를 물 주기로 갱신
+      setState(() {
+        dDayWater = widget.waterCycle; // 물 주기 값으로 설정
+      });
+    } catch (e) {
+      _showToast("업데이트 실패: $e");
+    }
+  }
+
 
   // 토스트 메시지 표시 함수
   void _showToast(String message) {
@@ -169,7 +220,7 @@ class PlantListItem extends StatelessWidget {
       mainAxisAlignment: MainAxisAlignment.center,
       crossAxisAlignment: CrossAxisAlignment.center,
       children: [
-        _dDayBadge('D+$dDayFertilizer', Color(0xFFE7B4BA)),
+        _dDayBadge('D+${widget.dDayFertilizer}', Color(0xFFE7B4BA)),
         const SizedBox(height: 8),
         _dDayBadge('D-$dDayWater', Color(0xFF95CED5)),
       ],

--- a/lib/widgets/components/plant_list_item.dart
+++ b/lib/widgets/components/plant_list_item.dart
@@ -144,8 +144,8 @@ class PlantListItem extends StatelessWidget {
       msg: message,
       toastLength: Toast.LENGTH_SHORT, // 지속 시간
       gravity: ToastGravity.CENTER, // 위치
-      backgroundColor: Color(0xFF4B7E5B),
-      textColor: Colors.white,
+      backgroundColor: Color(0xFFECF7F2),
+      textColor: Colors.black,
       fontSize: 13.0,
     );
   }


### PR DESCRIPTION
## 변경 사항

- 입력한 식물의 정보를 firebase에 저장했습니다.
- 정보를 PlantItem에 전달하고, 내식물모음페이지에 모두 보이도록 했습니다.
- 물주기 버튼을 누르면 남은날짜가 초기화 되도록 했습니다.

## 테스트 실행

- [x]  👍 Yes
- [ ]  🙅 No, Because they are not neaded
- [ ]  🤯 No, Because I needed help with writing tests

### 테스트 결과

![register](https://github.com/user-attachments/assets/0d67dec6-83ee-44a4-842d-8d4bd7f6ab85)

