### PR TITLE
[feat] 내식물타임라인페이지 기능 구현

### DIFF
--- a/lib/routes/plants_routes.dart
+++ b/lib/routes/plants_routes.dart
@@ -16,8 +16,11 @@ class PlantsRoutes {
           builder: (context, state) => MyPlantRegisterScreen(),
         ),
         GoRoute(
-          path: 'timeline', // /plants/timeline
-          builder: (context, state) => MyPlantTimelineScreen(),
+          path: 'timeline/:plantId', // /plants/timeline/식물고유ID
+          builder: (context, state) {
+            final plantId = state.pathParameters['plantId']!;
+            return MyPlantTimelineScreen(plantId: plantId);
+          },
         ),
       ],
     ),

--- a/lib/routes/plants_routes.dart
+++ b/lib/routes/plants_routes.dart
@@ -13,7 +13,14 @@ class PlantsRoutes {
       routes: [
         GoRoute(
           path: 'register', // /plants/register
-          builder: (context, state) => MyPlantRegisterScreen(),
+          builder: (context, state) {
+            final extra = state.extra as Map<String, dynamic>? ?? {};
+            return MyPlantRegisterScreen(
+              isEditing: extra['isEditing'] ?? false,
+              plantId: extra['plantId'] as String?,
+              plantData: extra['plantData'] as Map<String, dynamic>?,
+            );
+          },
         ),
         GoRoute(
           path: 'timeline/:plantId', // /plants/timeline/식물고유ID

--- a/lib/screens/modals/timeline_modal.dart
+++ b/lib/screens/modals/timeline_modal.dart
@@ -75,7 +75,7 @@ class TimelineModal extends StatelessWidget {
                     IconButton(
                       icon: const Icon(Icons.close, color: Colors.black, size: 24),
                       onPressed: () {
-                        Navigator.pop(context); // 모달창 닫기
+                        context.pop(); // 모달창 닫기
                       },
                     ),
                   ],
@@ -89,6 +89,7 @@ class TimelineModal extends StatelessWidget {
                     itemBuilder: (context, index) {
                       final memo = memos[index];
                       final data = memo.data() as Map<String, dynamic>;
+                      final memoId = memo.id;
 
                       return MemoItem(
                         date: (data['createdAt'] as Timestamp?)
@@ -99,6 +100,8 @@ class TimelineModal extends StatelessWidget {
                         content: data['content'] ?? '내용 없음',
                         imageUrl: data['imageUrl'] ?? '',
                         emojiIndex: data['emoji'] ?? 0,
+                        memoId: memoId,
+                        plantId: plantId,
                       );
                     },
                   ),

--- a/lib/screens/modals/timeline_modal.dart
+++ b/lib/screens/modals/timeline_modal.dart
@@ -1,72 +1,113 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 import '../../widgets/components/memo_item.dart';
 
 class TimelineModal extends StatelessWidget {
-  const TimelineModal({super.key});
+  final String plantId;
+  const TimelineModal({super.key, required this.plantId});
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      decoration: BoxDecoration(
-        color: Colors.white,
-        borderRadius: BorderRadius.only(
-          topLeft: Radius.circular(10),
-          topRight: Radius.circular(10),
-        ),
-      ),
-      child: Column(
-        children: [
-          // 모달의 AppBar
-          Container(
-            padding: EdgeInsets.symmetric(vertical: 10),
-            decoration: const BoxDecoration(
-              color: Colors.white,
-              borderRadius: BorderRadius.only(
-                topLeft: Radius.circular(10),
-                topRight: Radius.circular(10),
-              ),
-            ),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                const SizedBox(width: 48),
-                const Text(
-                  "타임라인",
-                  style: TextStyle(
-                    fontSize: 16,
-                    fontWeight: FontWeight.bold,
-                    color: Colors.black,
-                  ),
-                ),
-                IconButton(
-                  icon: const Icon(Icons.close, color: Colors.black, size: 24),
-                  onPressed: () {
-                    context.pop(); // 모달창 닫기
-                  },
-                ),
-              ],
+    final user = FirebaseAuth.instance.currentUser;
+
+    if (user == null) {
+      return const Center(child: Text('로그인된 사용자가 없습니다.'));
+    }
+
+    return StreamBuilder<QuerySnapshot>(
+      stream: FirebaseFirestore.instance
+          .collection('users')
+          .doc(user.uid)
+          .collection('plants')
+          .doc(plantId)
+          .collection('memos')
+          .orderBy('createdAt', descending: true) // 최신순 정렬
+          .snapshots(),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const Center(child: CircularProgressIndicator());
+        }
+
+        if (snapshot.hasError) {
+          return const Center(child: Text('오류가 발생했습니다.'));
+        }
+
+        if (!snapshot.hasData || snapshot.data!.docs.isEmpty) {
+          return const Center(child: Text('메모가 없습니다.'));
+        }
+
+        final memos = snapshot.data!.docs;
+
+        return Container(
+          decoration: BoxDecoration(
+            color: Colors.white,
+            borderRadius: const BorderRadius.only(
+              topLeft: Radius.circular(10),
+              topRight: Radius.circular(10),
             ),
           ),
-          Expanded(
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 15),
-              child: Column(
-                children: [
-                  Expanded(
-                    child: ListView.builder(
-                      itemCount: 5, // 예시 메모 개수
-                      itemBuilder: (context, index) {
-                        return MemoItem(); // 메모 아이템 memo_item.dart
+          child: Column(
+            children: [
+              // 모달의 AppBar
+              Container(
+                padding: const EdgeInsets.symmetric(vertical: 10),
+                decoration: const BoxDecoration(
+                  color: Colors.white,
+                  borderRadius: BorderRadius.only(
+                    topLeft: Radius.circular(10),
+                    topRight: Radius.circular(10),
+                  ),
+                ),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    const SizedBox(width: 48),
+                    const Text(
+                      "타임라인",
+                      style: TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.bold,
+                        color: Colors.black,
+                      ),
+                    ),
+                    IconButton(
+                      icon: const Icon(Icons.close, color: Colors.black, size: 24),
+                      onPressed: () {
+                        Navigator.pop(context); // 모달창 닫기
                       },
                     ),
-                  ),
-                ],
+                  ],
+                ),
               ),
-            ),
+              Expanded(
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 15),
+                  child: ListView.builder(
+                    itemCount: memos.length,
+                    itemBuilder: (context, index) {
+                      final memo = memos[index];
+                      final data = memo.data() as Map<String, dynamic>;
+
+                      return MemoItem(
+                        date: (data['createdAt'] as Timestamp?)
+                            ?.toDate()
+                            .toString()
+                            .substring(0, 10) ??
+                            '-',
+                        content: data['content'] ?? '내용 없음',
+                        imageUrl: data['imageUrl'] ?? '',
+                        emojiIndex: data['emoji'] ?? 0,
+                      );
+                    },
+                  ),
+                ),
+              ),
+            ],
           ),
-        ],
-      ),
+        );
+      },
     );
   }
 }

--- a/lib/screens/plants/my_plant_timeline_screen.dart
+++ b/lib/screens/plants/my_plant_timeline_screen.dart
@@ -200,7 +200,7 @@ class _MyPlantTimelineScreenState extends State<MyPlantTimelineScreen> {
         onPressed: () {
           showDialog(
             context: context,
-            builder: (context) => const MemoCreateModal(),
+            builder: (context) => MemoCreateModal(plantId: widget.plantId),
           );
         },
         backgroundColor: Colors.white, // 배경색 변경

--- a/lib/screens/plants/my_plant_timeline_screen.dart
+++ b/lib/screens/plants/my_plant_timeline_screen.dart
@@ -110,19 +110,6 @@ class _MyPlantTimelineScreenState extends State<MyPlantTimelineScreen> {
                     fontWeight: FontWeight.bold,
                   ),
                 ),
-                // 타임라인 리스트
-                // ListView(
-                //   padding: const EdgeInsets.all(16),
-                //   physics: NeverScrollableScrollPhysics(), // 내부 스크롤 비활성화
-                //   shrinkWrap: true,
-                //   children: memos.take(3).map((memo) { // 최근 3개의 Memo만 보이기
-                //     return MemoItem(
-                //       //date: memo['date'],
-                //       //content: memo['content'],
-                //       //imageUrl: memo['imageUrl'],
-                //     );
-                //   }).toList(),
-                // ),
                 _buildRecentMemos(), // 최신 메모 3개만 보이기
                 InkWell( // 더보기 버튼
                   onTap: () {
@@ -213,11 +200,28 @@ class _MyPlantTimelineScreenState extends State<MyPlantTimelineScreen> {
       ),
       centerTitle: true,
       actions: [
-        IconButton(
+        IconButton( // 수정 버튼
           icon: const Icon(
               Icons.edit_outlined, color: Color(0xFF7D7D7D), size: 24),
-          onPressed: () {
-            context.push('/plants/register'); // 내식물등록페이지로 이동
+          onPressed: () async {
+            final snapshot = await FirebaseFirestore.instance
+                .collection('users')
+                .doc(FirebaseAuth.instance.currentUser!.uid)
+                .collection('plants')
+                .doc(widget.plantId)
+                .get();
+
+            if (snapshot.exists) {
+              final plantData = snapshot.data();
+              context.push(
+                '/plants/register', // 내식물등록페이지로 이동
+                extra: {
+                  'isEditing': true,
+                  'plantId': widget.plantId,
+                  'plantData': plantData,
+                },
+              );
+            }
           },
         ),
         IconButton(

--- a/lib/screens/plants/my_plant_timeline_screen.dart
+++ b/lib/screens/plants/my_plant_timeline_screen.dart
@@ -401,7 +401,10 @@ class _MyPlantTimelineScreenState extends State<MyPlantTimelineScreen> {
                     5,
                         (index) => Padding(
                       padding: const EdgeInsets.symmetric(horizontal: 5.0),
-                      child: Icon(Icons.wb_sunny, color: Color(0xFFFDD941)),
+                      child: Icon(
+                        Icons.wb_sunny,
+                        color: index < sunlightLevel ? Color(0xFFFDD941) : Color(0x4DFDD941),
+                      ),
                     ),
                   ),
                 ),
@@ -427,7 +430,10 @@ class _MyPlantTimelineScreenState extends State<MyPlantTimelineScreen> {
                     5,
                         (index) => Padding(
                       padding: const EdgeInsets.symmetric(horizontal: 5.0),
-                      child: Icon(Icons.water_drop, color: Color(0xFF8FD7FF)),
+                      child: Icon(
+                        Icons.water_drop,
+                        color: index < waterLevel ? Color(0xFF8FD7FF) : Color(0x4D8FD7FF),
+                      ),
                     ),
                   ),
                 ),

--- a/lib/screens/plants/my_plant_timeline_screen.dart
+++ b/lib/screens/plants/my_plant_timeline_screen.dart
@@ -165,18 +165,18 @@ class _MyPlantTimelineScreenState extends State<MyPlantTimelineScreen> {
                   ),
                 ),
                 // 타임라인 리스트
-                ListView(
-                  padding: const EdgeInsets.all(16),
-                  physics: NeverScrollableScrollPhysics(), // 내부 스크롤 비활성화
-                  shrinkWrap: true,
-                  children: memos.take(3).map((memo) { // 최근 3개의 Memo만 보이기
-                    return MemoItem(
-                      //date: memo['date'],
-                      //content: memo['content'],
-                      //imageUrl: memo['imageUrl'],
-                    );
-                  }).toList(),
-                ),
+                // ListView(
+                //   padding: const EdgeInsets.all(16),
+                //   physics: NeverScrollableScrollPhysics(), // 내부 스크롤 비활성화
+                //   shrinkWrap: true,
+                //   children: memos.take(3).map((memo) { // 최근 3개의 Memo만 보이기
+                //     return MemoItem(
+                //       //date: memo['date'],
+                //       //content: memo['content'],
+                //       //imageUrl: memo['imageUrl'],
+                //     );
+                //   }).toList(),
+                // ),
                 InkWell( // 더보기 버튼
                   onTap: () {
                     _showTimeLineModal(context);
@@ -568,7 +568,7 @@ class _MyPlantTimelineScreenState extends State<MyPlantTimelineScreen> {
       builder: (BuildContext context) {
         return FractionallySizedBox(
           heightFactor: 0.85, // 화면 높이의 85%로 설정
-          child: TimelineModal(), // comment_modal.dart에 정의된 위젯
+          child: TimelineModal(plantId: widget.plantId,), // comment_modal.dart에 정의된 위젯
         );
       },
     );

--- a/lib/screens/plants/my_plant_timeline_screen.dart
+++ b/lib/screens/plants/my_plant_timeline_screen.dart
@@ -31,12 +31,12 @@ class _MyPlantTimelineScreenState extends State<MyPlantTimelineScreen> {
     final user = FirebaseAuth.instance.currentUser;
 
     if (user == null) {
-      throw Exception("로그인된 사용자가 없습니다."); // 사용자가 로그인되지 않은 경우 예외 발생
+      throw Exception("로그인된 사용자가 없습니다.");
     }
 
     return FirebaseFirestore.instance
         .collection('users')
-        .doc(user.uid) // 로그인된 사용자의 UID를 사용
+        .doc(user.uid) // 로그인된 사용자의 UID
         .collection('plants')
         .doc(widget.plantId)
         .get();
@@ -570,12 +570,15 @@ class _MyPlantTimelineScreenState extends State<MyPlantTimelineScreen> {
           itemBuilder: (context, index) {
             final memo = memos[index];
             final data = memo.data() as Map<String, dynamic>;
+            final memoId = memo.id;
 
             return MemoItem(
               date: (data['createdAt'] as Timestamp?)?.toDate().toString().substring(0, 10) ?? '-',
               content: data['content'] ?? '내용 없음',
               imageUrl: data['imageUrl'] ?? '',
               emojiIndex: data['emoji'] ?? 0,
+              memoId: memoId,
+              plantId: widget.plantId,
             );
           },
         );

--- a/lib/screens/plants/my_plant_timeline_screen.dart
+++ b/lib/screens/plants/my_plant_timeline_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:fluttertoast/fluttertoast.dart';
 import '../modals/notification_setting_modal.dart';
 import '../modals/memo_create_modal.dart';
 import '../modals/timeline_modal.dart';
@@ -224,7 +225,7 @@ class _MyPlantTimelineScreenState extends State<MyPlantTimelineScreen> {
             }
           },
         ),
-        IconButton(
+        IconButton( // 삭제 버튼
           icon: const Icon(
               Icons.delete_outlined, color: Color(0xFFDA2525), size: 24),
           onPressed: () {
@@ -252,8 +253,7 @@ class _MyPlantTimelineScreenState extends State<MyPlantTimelineScreen> {
             ),
             TextButton(
               onPressed: () {
-                context.go('/plants'); // 내식물모음페이지로 이동
-                // 삭제 기능 구현
+                _deletePlant(context);
               },
               child: Text("예"),
             ),
@@ -261,6 +261,46 @@ class _MyPlantTimelineScreenState extends State<MyPlantTimelineScreen> {
         );
       },
     );
+  }
+
+  // firebase에서 삭제
+  Future<void> _deletePlant(BuildContext context) async {
+    try {
+      final user = FirebaseAuth.instance.currentUser;
+      if (user == null) {
+        throw Exception("로그인된 사용자가 없습니다.");
+      }
+
+      await FirebaseFirestore.instance
+          .collection('users')
+          .doc(user.uid)
+          .collection('plants')
+          .doc(widget.plantId)
+          .delete();
+
+      // 삭제 성공 메시지
+      Fluttertoast.showToast(
+        msg: "식물 삭제 완료",
+        toastLength: Toast.LENGTH_SHORT,
+        gravity: ToastGravity.CENTER,
+        backgroundColor: Color(0xFF4B7E5B),
+        textColor: Colors.white,
+        fontSize: 13.0,
+      );
+
+      // 식물 모음 페이지로 이동
+      context.go('/plants');
+    } catch (e) {
+      // 삭제 실패 메시지 표시
+      Fluttertoast.showToast(
+        msg: "삭제 실패..",
+        toastLength: Toast.LENGTH_SHORT,
+        gravity: ToastGravity.BOTTOM,
+        backgroundColor: Color(0xFFE81010),
+        textColor: Colors.white,
+        fontSize: 13.0,
+      );
+    }
   }
 
   // 함께한지 D+Day 뱃지

--- a/lib/widgets/components/memo_item.dart
+++ b/lib/widgets/components/memo_item.dart
@@ -1,23 +1,28 @@
 import 'package:flutter/material.dart';
+import 'dart:io';
 
 // 메모 하나
 class MemoItem extends StatelessWidget {
-  // ------- 메모 정보 가져올때 주석 풀기
-  //final String date;
-  //final String content;
-  //final String imageUrl;
+  final String date; // 작성 날짜
+  final String content; // 메모 내용
+  final String imageUrl; // 이미지 경로
+  final int emojiIndex; // 이모지 인덱스
   //final VoidCallback onTap;
 
-  const MemoItem({super.key}
-    //super.key,
-    //required this.date,
-    //required this.content,
-    //required this.imageUrl,
+  const MemoItem({
+    super.key,
+    required this.date,
+    required this.content,
+    required this.imageUrl,
+    required this.emojiIndex,
     //required this.onTap,
-  );
+  });
 
   @override
   Widget build(BuildContext context) {
+    const emojis = ['😆', '😊', '😐', '😞', '😭'];
+    final file = File(imageUrl);
+
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 5),
       child: Container(
@@ -33,18 +38,17 @@ class MemoItem extends StatelessWidget {
               child: Container(
                 width: 20,
                 height: 20,
-                color: Colors.white,
+                color: Color(0x99ECF7F2),
                 alignment: Alignment.center,
-                child: Icon(
-                  Icons.sentiment_very_satisfied,
-                  size: 20, // 아이콘 크기
-                  color: Color(0xFFFFDE00),
+                child: Text(
+                  emojis[emojiIndex],
+                  style: const TextStyle(fontSize: 15),
                 ),
               ),
             ),
             const SizedBox(width: 8),
             Text( // 작성 날짜
-              "2024.10.06", // date
+              date, // date
               style: TextStyle(
                 fontSize: 8,
                 fontWeight: FontWeight.bold,
@@ -57,18 +61,18 @@ class MemoItem extends StatelessWidget {
                 children: [
                   SizedBox(height: 10),
                   Text( // 메모 내용
-                    "메모 내용이 표시됩니다.",
+                    content,
                     style: TextStyle(
                       fontSize: 10,
                       color: Colors.black,
                     ),
                   ),
                   SizedBox(height: 7),
-                  //if (imageUrl != null && imageUrl.isNotEmpty) // 메모 이미지가 있다면
+                  if (imageUrl != null && imageUrl.isNotEmpty) // 메모 이미지가 있다면
                     ClipRRect(
                       borderRadius: BorderRadius.circular(10),
-                      child: Image.asset(
-                        "assets/images/plant1.png", //imageUrl, // 이미지 경로
+                      child: Image.file(
+                        File(imageUrl), // 이미지 경로
                         width: 150,
                         height: 150,
                         fit: BoxFit.cover,

--- a/lib/widgets/components/plant_list_item.dart
+++ b/lib/widgets/components/plant_list_item.dart
@@ -41,7 +41,7 @@ class _PlantListItemState extends State<PlantListItem> {
   Widget build(BuildContext context) {
     return GestureDetector(
       onTap: () {
-        context.push('/plants/timeline'); // 내식물타임라인페이지로 이동(/$id 추가)
+        context.push('/plants/timeline/${widget.plantId}'); // 내식물타임라인페이지로 이동
       },
       child: SizedBox(
         height: 130, // Card 높이 고정


### PR DESCRIPTION
## 변경 사항

- 이름, 사진, LIKE, D-DAY에 내식물등록페이지에서 저장한 데이터를 보이게 했습니다.
- 메모 작성을 한 뒤, MemoItem에 해당 데이터를 전달 했습니다. (작성시간, 내용, 사진)
- 타임라인모달창에 MemoItem 리스트를 보이도록 했습니다.
- 하단 "타임라인" 부분에 MemoItem들 중 최신 3개만 보이도록 했습니다.
- 메모 삭제 기능을 구현했습니다.
- 식물 수정, 삭제 기능을 구현했습니다.

## 테스트 실행

- [x]  👍 Yes
- [ ]  🙅 No, Because they are not neaded
- [ ]  🤯 No, Because I needed help with writing tests

### 테스트 결과

![memo](https://github.com/user-attachments/assets/8af8ce27-5dc2-4c73-a69c-1345e226a1b2)

<img width="192" alt="스크린샷 2024-12-04 210339" src="https://github.com/user-attachments/assets/927d9414-9f30-46d2-b423-175ad3083177">

